### PR TITLE
Back ported scripts to support Zeek 3.0.0

### DIFF
--- a/scripts/check-addressscan.bro
+++ b/scripts/check-addressscan.bro
@@ -273,7 +273,7 @@ function check_AddressScan(cid: conn_id, established: bool, reverse: bool): bool
 			if (enable_big_tables) 
 			{ 
 				if ( orig !in distinct_peers )
-					distinct_peers[orig] = set() &mergeable;
+					distinct_peers[orig] = set() ; ##&mergeable;
 
 				if ( resp !in distinct_peers[orig] )
 					add distinct_peers[orig][resp];
@@ -363,7 +363,7 @@ function check_AddressScan(cid: conn_id, established: bool, reverse: bool): bool
 #		        { return; }
 #
 #        if ([orig] !in distinct_peers)
-#                distinct_peers[orig]=set() &mergeable;
+#                distinct_peers[orig]=set() ; ##&mergeable;
 #
 #        add distinct_peers[orig][resp];
 #

--- a/scripts/check-addressscan.bro
+++ b/scripts/check-addressscan.bro
@@ -289,8 +289,7 @@ function check_AddressScan(cid: conn_id, established: bool, reverse: bool): bool
 					if ((service in likely_server_ports && n > 99) || (service !in likely_server_ports)) 
 					{ 
 						NOTICE([$note=AddressScan,
-							$src=orig, $p=service, $n=n,
-							$src_peer=get_local_event_peer(), 
+							$src=orig, $p=service, $n=n, 
 							$msg=fmt("%s has scanned %d hosts (%s)", orig, n, service)]);
 					 
 						log_reporter (fmt ("NOTICE: FOUND AddressScan: %s", orig),0);
@@ -321,7 +320,6 @@ function check_AddressScan(cid: conn_id, established: bool, reverse: bool): bool
 				log_reporter(fmt("AddressScan NOTICE %s has scanned %d hosts (%s)", orig, d_val, service),0); 
                                NOTICE([$note=AddressScan,
                                        $src=orig, $p=service, $n=d_val,
-                                       $src_peer=get_local_event_peer(),
                                        $msg=fmt("%s has scanned %d hosts (%s)", orig, d_val, service)]);
 
                                result = T ;

--- a/scripts/check-backscatter.bro
+++ b/scripts/check-backscatter.bro
@@ -75,7 +75,7 @@ function c_check_backscatter_thresholds(orig: addr, s_port: port, resp: addr): b
                         {
                                 #print fmt("CARDINAL: backscatter seen from %s (%d port: %s)", orig, |distinct_backscatter_peers[orig]|, s_port) ;
 				NOTICE([$note=BackscatterSeen, $src=orig,
-                                                $p=s_port, $src_peer=get_local_event_peer(),
+                                                $p=s_port,
                                                 $msg=fmt("backscatter seen from %s (%d port: %s)",
                                                         orig, d_val, s_port)]);
 
@@ -119,7 +119,7 @@ function check_backscatter_thresholds(orig: addr, rev_svc: port, resp: addr): bo
                         if (|distinct_backscatter_peers[orig][rev_svc][resp]| >= BACKSCATTER_THRESH)
                         {
                                 NOTICE([$note=BackscatterSeen, $src=orig,
-                                                $p=rev_svc, $src_peer=get_local_event_peer(), 
+                                                $p=rev_svc, 
                                                 $msg=fmt("backscatter seen from %s (%d port: %s)",
                                                         orig, |distinct_backscatter_peers[orig]|, rev_svc)]);
 				## is a scanner now 

--- a/scripts/check-backscatter.bro
+++ b/scripts/check-backscatter.bro
@@ -99,7 +99,7 @@ function check_backscatter_thresholds(orig: addr, rev_svc: port, resp: addr): bo
 	local result = F; 
 	
         if ( orig !in distinct_backscatter_peers)
-                distinct_backscatter_peers[orig] = table() &mergeable;
+                distinct_backscatter_peers[orig] = table() ; ##&mergeable;
 
 	if (|distinct_backscatter_peers[orig]| > BACKSCATTER_PORT_THRESH)
 	{ return F ; } 
@@ -110,7 +110,7 @@ function check_backscatter_thresholds(orig: addr, rev_svc: port, resp: addr): bo
         if (|distinct_backscatter_peers[orig]| <= BACKSCATTER_PORT_THRESH)
         {
 		if (rev_svc !in distinct_backscatter_peers[orig]) 
-			distinct_backscatter_peers[orig][rev_svc] = set() &mergeable;
+			distinct_backscatter_peers[orig][rev_svc] = set() ; ##&mergeable;
 
                 if ( resp !in distinct_backscatter_peers[orig][rev_svc] )
                 {

--- a/scripts/check-knock.bro
+++ b/scripts/check-knock.bro
@@ -171,8 +171,7 @@ function check_knockknock_scan(orig: addr, d_port: port, resp: addr): bool
 
 		local _msg = fmt("%s scanned a total of %d hosts: [%s] (port-flux-density: %s) (origin: %s distance: %.2f miles)", orig, d_val,d_port, |concurrent_scanners_per_port[d_port]|, cc, distance);
 
-		NOTICE([$note=KnockKnockScan, $src=orig,
-				 $src_peer=get_local_event_peer(), $msg=fmt("%s", _msg), $identifier=cat(orig), $suppress_for=1 mins]);
+		NOTICE([$note=KnockKnockScan, $src=orig, $msg=fmt("%s", _msg), $identifier=cat(orig), $suppress_for=1 mins]);
 		log_reporter (fmt ("NOTICE: FOUND KnockKnockScan: %s", orig),0);
 
 	} 

--- a/scripts/check-knock.bro
+++ b/scripts/check-knock.bro
@@ -80,8 +80,8 @@ export {
 	global concurrent_scanners_per_port: table[port] of set[addr] &write_expire=6 hrs ; #### &synchronized ; 
 	
 	### clusterization helper events 
-	global m_w_knockscan_add: event (orig: addr, d_port: port,  resp: addr);
-	global w_m_knockscan_new: event (orig: addr, d_port: port,  resp: addr);
+	global Scan::m_w_knockscan_add: event (orig: addr, d_port: port,  resp: addr);
+	global Scan::w_m_knockscan_new: event (orig: addr, d_port: port,  resp: addr);
 	global add_to_knockknock_cache: function(orig: addr, d_port: port,  resp: addr);
 
 	global check_knockknock_scan: function(orig: addr, d_port: port, resp: addr): bool  ; 
@@ -314,8 +314,16 @@ function filterate_KnockKnockScan(c: connection, darknet: bool ): string
 
 }
 
-
+@ifndef(zeek_init)
+#Running on old bro that doesn't know about zeek events
+global zeek_init: event();
 event bro_init()
+{
+    event zeek_init();
+}
+@endif
+
+event zeek_init()
 {
 
 Input::add_table([$source=ipportexclude_file, $name="ipportexclude", $idx=ipportexclude_Idx, $val=ipportexclude_Val,  $destination=ipportexclude, $mode=Input::REREAD ]);

--- a/scripts/check-landmine.bro
+++ b/scripts/check-landmine.bro
@@ -70,7 +70,7 @@ function check_LandMine(cid: conn_id, established: bool, reversed: bool ): bool
 	} 
 	
 #	if ([orig] !in landmine_distinct_peers)
-#		landmine_distinct_peers[orig]=set() &mergeable;
+#		landmine_distinct_peers[orig]=set() ; ##&mergeable;
 #			
 #	if([resp] !in landmine_distinct_peers[orig])
 #	{

--- a/scripts/check-landmine.bro
+++ b/scripts/check-landmine.bro
@@ -86,7 +86,7 @@ function check_LandMine(cid: conn_id, established: bool, reversed: bool ): bool
 #			{ iplist += fmt (" %s", ip); }
 #
 #			local msg = fmt("landmine address trigger %s [%s] %s", orig, d_port, iplist );
-#			NOTICE([$note=LandMine, $src=orig, $src_peer=get_local_event_peer(), $msg=msg, $identifier=cat(orig)]);
+#			NOTICE([$note=LandMine, $src=orig, $msg=msg, $identifier=cat(orig)]);
 #			log_reporter (fmt ("NOTICE: FOUND LandMine : %s", orig),0);
 #
 #			return T; 
@@ -108,7 +108,7 @@ function check_LandMine(cid: conn_id, established: bool, reversed: bool ): bool
 	if (d_val  >= landmine_thresh_trigger)  
 	{	
 		local msg=fmt ("Landmine hit by %s", orig); 
-		NOTICE([$note=LandMine, $src=orig, $src_peer=get_local_event_peer(), $msg=msg, $identifier=cat(orig)]);
+		NOTICE([$note=LandMine, $src=orig, $msg=msg, $identifier=cat(orig)]);
 		log_reporter (fmt ("NOTICE: FOUND LandMine : %s, %s", orig, network_time()),0);
 		return T ; 
 

--- a/scripts/check-landmine.bro
+++ b/scripts/check-landmine.bro
@@ -26,7 +26,7 @@ export
 
 	###	Expire functions that trigger summaries.
         global c_landmine_scan_summary:
-                function(t: table[addr] of set[addr], orig: addr): interval;
+                function(t: table[addr] of opaque of cardinality, orig: addr): interval;
 
 	global c_landmine_distinct_peers: table[addr] of opaque of cardinality 
 		&default = function(n: any): opaque of cardinality { return hll_cardinality_init(0.1, 0.99); }

--- a/scripts/check-lowporttroll.bro
+++ b/scripts/check-lowporttroll.bro
@@ -76,8 +76,7 @@ function check_LowPortTroll(cid: conn_id, established: bool, reverse: bool): boo
 
 
 			local svrc_msg = fmt("low port trolling %s %s", orig, s);
-			NOTICE([$note=LowPortTrolling, $src=orig,
-				$src_peer=get_local_event_peer(), 
+			NOTICE([$note=LowPortTrolling, $src=orig, 
 				$p=service, $msg=svrc_msg]);
 
 			troll = T ; 

--- a/scripts/check-lowporttroll.bro
+++ b/scripts/check-lowporttroll.bro
@@ -64,7 +64,7 @@ function check_LowPortTroll(cid: conn_id, established: bool, reverse: bool): boo
 	     service !in distinct_low_ports[orig] )
 		{
 		if ( orig !in distinct_low_ports )
-			distinct_low_ports[orig] = set() &mergeable;
+			distinct_low_ports[orig] = set() ; ##&mergeable;
 
 		add distinct_low_ports[orig][service];
 

--- a/scripts/check-portscan.bro
+++ b/scripts/check-portscan.bro
@@ -157,8 +157,7 @@ function check_lowporttrolling(orig: addr, service: port, resp: addr): bool
 
 
 			local svrc_msg = fmt("low port trolling %s %s", orig, s);
-			NOTICE([$note=LowPortTrolling, $src=orig,
-				$src_peer=get_local_event_peer(), 
+			NOTICE([$note=LowPortTrolling, $src=orig, 
 				$p=service, $msg=svrc_msg]);
 
 			troll = T ; 
@@ -194,7 +193,6 @@ function check_portscan_thresh(orig: addr, service:port, resp: addr): bool
 			local m = |scan_triples[orig][resp]|;
 			NOTICE([$note=PortScan, $n=m, $src=orig,
 				$p=service,
-				$src_peer=get_local_event_peer(), 
 				$msg=fmt("%s has scanned %d ports of %s",
 				orig, m, resp)]);
 			return T ; 

--- a/scripts/check-portscan.bro
+++ b/scripts/check-portscan.bro
@@ -145,7 +145,7 @@ function check_lowporttrolling(orig: addr, service: port, resp: addr): bool
 	     service !in distinct_low_ports[orig] )
 		{
 		if ( orig !in distinct_low_ports )
-			distinct_low_ports[orig] = set() &mergeable;
+			distinct_low_ports[orig] = set() ; ##&mergeable;
 
 		add distinct_low_ports[orig][service];
 
@@ -177,10 +177,10 @@ function check_portscan_thresh(orig: addr, service:port, resp: addr): bool
 {
 
 	if ( orig !in scan_triples )
-		scan_triples[orig] = table() &mergeable;
+		scan_triples[orig] = table() ; ##&mergeable;
 
 	if ( resp !in scan_triples[orig] )
-		scan_triples[orig][resp] = set() &mergeable;
+		scan_triples[orig][resp] = set() ; ##&mergeable;
 
 	if ( service !in scan_triples[orig][resp] )
 	{
@@ -242,7 +242,7 @@ function check_PortScan(c: connection, established: bool, reverse: bool)
 	if ( orig !in distinct_ports || service !in distinct_ports[orig] )
 		{
 		if ( orig !in distinct_ports )
-			distinct_ports[orig] = set() &mergeable;
+			distinct_ports[orig] = set() ; ##&mergeable;
 
 		if ( service !in distinct_ports[orig] )
 			add distinct_ports[orig][service];
@@ -250,7 +250,7 @@ function check_PortScan(c: connection, established: bool, reverse: bool)
 		if ( |distinct_ports[orig]| >= possible_port_scan_thresh &&
 			orig !in scan_triples )
 			{
-			scan_triples[orig] = table() &mergeable;
+			scan_triples[orig] = table() ; ##&mergeable;
 			add possible_scan_sources[orig];
 			}
 		}
@@ -301,7 +301,7 @@ event Scan::w_m_portscan_new(orig: addr, service: port, resp: addr, outbound: bo
 	  if ( orig !in distinct_ports || service !in distinct_ports[orig] )
                 {
                 if ( orig !in distinct_ports )
-                        distinct_ports[orig] = set() &mergeable;
+                        distinct_ports[orig] = set() ; ##&mergeable;
 
                 if ( service !in distinct_ports[orig] )
                         add distinct_ports[orig][service];
@@ -309,7 +309,7 @@ event Scan::w_m_portscan_new(orig: addr, service: port, resp: addr, outbound: bo
                 if ( |distinct_ports[orig]| >= possible_port_scan_thresh &&
                         orig !in scan_triples )
                         {
-                        scan_triples[orig] = table() &mergeable;
+                        scan_triples[orig] = table() ; ##&mergeable;
                         add possible_scan_sources[orig];
                         }
                 }

--- a/scripts/check-scan-impl.bro
+++ b/scripts/check-scan-impl.bro
@@ -139,7 +139,8 @@ function check_scan_cache(c: connection, established: bool, reverse: bool, filtr
 
         ### if standalone then we check on bro node else we deligate manager to handle this
         @if ( Cluster::is_enabled() )
-                event Scan::w_m_new_scanner(ci, established, reverse, filtrator);
+                #event Scan::w_m_new_scanner(ci, established, reverse, filtrator);
+		Broker::publish(Cluster::manager_topic, Scan::w_m_new_scanner, ci, established, reverse, filtrator);
         @else
 		populate_table_start_ts(ci); 
 		run_scan_detection (ci, established, reverse, filtrator) ;
@@ -155,10 +156,11 @@ function check_scan_cache(c: connection, established: bool, reverse: bool, filtr
 ## established: bool - if connect was established 
 ## reverse: bool 
 ## filtrator: string - comprises of K,L,A,B depending on which one of the filteration was successful 
-@if ( Cluster::is_enabled() && Cluster::local_node_type() == Cluster::MANAGER )
+#@if ( Cluster::is_enabled() && Cluster::local_node_type() == Cluster::MANAGER )
+
 event Scan::w_m_new_scanner(ci: conn_info, established: bool, reverse: bool, filtrator: string )
 {
-
+@if ( Cluster::is_enabled() && Cluster::local_node_type() == Cluster::MANAGER )
 	if (gather_statistics)
        	{
        		s_counters$worker_to_manager_counter += 1;
@@ -188,33 +190,39 @@ event Scan::w_m_new_scanner(ci: conn_info, established: bool, reverse: bool, fil
 		# if successful scanner, dispatch it to all workers 
 		# this is needed to keep known_scanners table syncd on all workers 
 
-		event Scan::m_w_add_scanner(known_scanners[orig]); 
+		#event Scan::m_w_add_scanner(known_scanners[orig]); 
+		Broker::publish(Cluster::worker_topic, Scan::m_w_add_scanner, known_scanners[orig]);
+		
         }
 @endif 
 
-}
 @endif
+}
+#@endif
 
 
 ### update workers with new scanner info
-@if ( Cluster::is_enabled() && Cluster::local_node_type() != Cluster::MANAGER )
+#@if ( Cluster::is_enabled() && Cluster::local_node_type() != Cluster::MANAGER )
+
 event Scan::m_w_add_scanner (ss: scan_info) 
 {
+@if ( Cluster::is_enabled() && Cluster::local_node_type() == Cluster::WORKER )
 	#log_reporter(fmt ("check-scan-impl: m_w_add_scanner: %s", ss$scanner), 0);
 
 	local orig = ss$scanner; 
 	local detection = ss$detection ; 
         Scan::add_to_known_scanners(orig, detection );
-	
+@endif	
 }
-@endif
+#@endif
 
 ## in the event when catch-n-release releases an IP - we change the known_scanners[ip]$status = F 
 ## so that workers again start sending conn_info to manager to reflag as scanner. 
-@if ( Cluster::is_enabled() && Cluster::local_node_type() == Cluster::MANAGER )
+#@if ( Cluster::is_enabled() && Cluster::local_node_type() == Cluster::MANAGER )
+
 event Scan::w_m_update_scanner(ss: scan_info) 
 {
-
+@if ( Cluster::is_enabled() && Cluster::local_node_type() == Cluster::MANAGER )
 	#log_reporter(fmt ("check-scan-impl: w_m_update_scanner: %s, %s", ss$scanner, ss$detection), 0);
 	if ( ss$scanner !in Scan::known_scanners) 
 	{ 
@@ -224,15 +232,18 @@ event Scan::w_m_update_scanner(ss: scan_info)
 	### now that Manager added the worker reported portscan to its known_scanner
 	#### manager needs to inform other workers of this new scanner 
 
-	event Scan::m_w_add_scanner(ss); 
+	#event Scan::m_w_add_scanner(ss); 
+	Broker::publish(Cluster::worker_topic, Scan::m_w_add_scanner, ss);
+@endif	
 } 
 
-@endif 
+#@endif 
 
-@if ( Cluster::is_enabled() && Cluster::local_node_type() != Cluster::MANAGER )
+#@if ( Cluster::is_enabled() && Cluster::local_node_type() != Cluster::MANAGER )
 
 event Scan::m_w_update_scanner (ip: addr, status_flag: bool )
 { 
+@if ( Cluster::is_enabled() && Cluster::local_node_type() != Cluster::MANAGER )
 
 	#log_reporter(fmt ("check-scan-impl: m_w_update_scanner: %s, %s", ip, status_flag), 0);
 	
@@ -242,22 +253,24 @@ event Scan::m_w_update_scanner (ip: addr, status_flag: bool )
 	} 
 	else 
 		log_reporter(fmt ("check-scan-impl: m_w_update_scanner: %s, %s NOT found in known_scanners - PROBLEM", ip, status_flag), 0);
-
-
-} 
 @endif 
 
+} 
+#@endif 
 
-@if ( Cluster::is_enabled() && Cluster::local_node_type() != Cluster::MANAGER )
+
+#@if ( Cluster::is_enabled() && Cluster::local_node_type() != Cluster::MANAGER )
 event Scan::m_w_remove_scanner(ip: addr) 
 {
+@if ( Cluster::is_enabled() && Cluster::local_node_type() == Cluster::WORKER )
 	if (ip in known_scanners)
 	{ 
 		log_reporter(fmt("m_w_remove_scanner: %s", known_scanners[ip]),0); 
 		delete known_scanners[ip] ; 
 	} 
+@endif 	
 } 
-@endif 
+#@endif 
 
 
 ## populates known_scanners table and if scan_summary is enabled then 

--- a/scripts/check-scan-impl.bro
+++ b/scripts/check-scan-impl.bro
@@ -243,7 +243,7 @@ event Scan::w_m_update_scanner(ss: scan_info)
 
 event Scan::m_w_update_scanner (ip: addr, status_flag: bool )
 { 
-@if ( Cluster::is_enabled() && Cluster::local_node_type() != Cluster::MANAGER )
+@if ( Cluster::is_enabled() && Cluster::local_node_type() == Cluster::WORKER )
 
 	#log_reporter(fmt ("check-scan-impl: m_w_update_scanner: %s, %s", ip, status_flag), 0);
 	

--- a/scripts/check-scan.bro
+++ b/scripts/check-scan.bro
@@ -22,7 +22,7 @@ global check_scan: function (c: connection, established: bool, reverse: bool);
 
 global uid_table: table[string] of bool &default=F &create_expire=5 mins ;
 
-event bro_init()
+event zeek_init()
 { 
 	event table_sizes() ; 
 }	

--- a/scripts/check-scan.bro
+++ b/scripts/check-scan.bro
@@ -24,7 +24,7 @@ global uid_table: table[string] of bool &default=F &create_expire=5 mins ;
 
 event zeek_init()
 { 
-	event table_sizes() ; 
+	event Scan::table_sizes() ; 
 }	
 
 ## Checks if a perticular connection is already blocked and managed by netcontrol

--- a/scripts/check-scan.bro
+++ b/scripts/check-scan.bro
@@ -1,6 +1,15 @@
 ### this is the core module which integrates and enables and disables 
 ### all the scan-detection suite 
 
+@ifndef(zeek_init)
+#Running on old bro that doesn't know about zeek events
+global zeek_init: event();
+event bro_init()
+{
+    event zeek_init();
+}
+@endif
+
 module Scan;
 
 export { 

--- a/scripts/conn-history.bro
+++ b/scripts/conn-history.bro
@@ -2,6 +2,15 @@ module History;
 
 @load ./debug.bro 
 
+@ifndef(zeek_init)
+#Running on old bro that doesn't know about zeek events
+global zeek_init: event();
+event bro_init()
+{
+    event zeek_init();
+}
+@endif
+
 export {
 	const DEBUG = 0 ; 
 
@@ -17,8 +26,8 @@ export {
 	  LongDuration, 
 	} ; 
 
-	global m_w_add: event (ip: addr);
-	global w_m_new: event (ip: addr);
+	global History::m_w_add: event (ip: addr);
+	global History::w_m_new: event (ip: addr);
         global add_to_bloom: function(ip: addr);
 
 	global check_conn_history: function (ip: addr): bool ; 
@@ -56,7 +65,7 @@ function check_conn_history(ip: addr): bool
 	return result ; 
 } 
 
-event bro_init()
+event zeek_init()
 {
 	# on avg we see 6.2M ip address a day 2016-04-01
 	# so setting bloom to 40M 
@@ -73,8 +82,8 @@ event bro_init()
 
 @if ( Cluster::is_enabled() )
 @load base/frameworks/cluster
-redef Cluster::manager2worker_events += /History::m_w_add/;
-redef Cluster::worker2manager_events += /History::w_m_new/;
+#redef Cluster::manager2worker_events += /History::m_w_add/;
+#redef Cluster::worker2manager_events += /History::w_m_new/;
 @endif
 
 
@@ -87,7 +96,8 @@ function add_to_bloom(ip: addr)
 		bloomfilter_add(tcp_outgoing_SF, ip);
 
 @if ( Cluster::is_enabled() )
-	        event History::w_m_new(ip);
+	        #event History::w_m_new(ip);
+		Broker::publish(Cluster::manager_topic, History::w_m_new, ip);
         	#log_reporter(fmt ("add_to_bloom %s", ip), 0);
 @endif
 	} 
@@ -95,13 +105,15 @@ function add_to_bloom(ip: addr)
 }
 
 
-@if ( Cluster::is_enabled() && Cluster::local_node_type() == Cluster::MANAGER )
+#@if ( Cluster::is_enabled() && Cluster::local_node_type() == Cluster::MANAGER )
 event History::w_m_new(ip: addr)
 {
+@if ( Cluster::is_enabled() && Cluster::local_node_type() == Cluster::MANAGER )
 	#log_reporter(fmt ("History: w_m_new: %s", ip), 0);
 	bloomfilter_add(tcp_outgoing_SF, ip);
-}
 @endif
+}
+#@endif
 
 
 # so that we have all the flags etc

--- a/scripts/conn-history.bro
+++ b/scripts/conn-history.bro
@@ -19,7 +19,7 @@ export {
 
 	global blocked_scanners : opaque of bloomfilter ; 
 	global ever_touched : opaque of bloomfilter ; 
-	global initialized_bloom: bool = F  &persistent ; 
+	global initialized_bloom: bool = F ;  ##&persistent ; 
 
 	redef enum Notice::Type += {
 	  SF_to_Scanner, # If ever a TCP_ESTABLISHED to the potential Scanner

--- a/scripts/host-profiling.bro
+++ b/scripts/host-profiling.bro
@@ -117,7 +117,9 @@ event Site::w_m_new_host_profile(cid: conn_id)
 		add host_profiles[resp][d_port] ;
 		log_host_profiles(cid); 
 	} 
-	event Site::m_w_add_host_profiles(cid);
+	#event Site::m_w_add_host_profiles(cid);
+	Broker::publish(Cluster::worker_topic, Site::m_w_add_host_profiles, cid);
+	
 @endif
 }
 #@endif

--- a/scripts/icmp-new-scan.bro
+++ b/scripts/icmp-new-scan.bro
@@ -75,7 +75,7 @@ function check_scan(orig: addr, resp: addr):bool
                 {
                 if ( orig !in ICMP::distinct_peers )
                         {
-                        local empty_peer_set: set[addr] &mergeable;
+                        local empty_peer_set: set[addr] ; ##&mergeable;
                         ICMP::distinct_peers[orig] = empty_peer_set;
                         }
 
@@ -114,7 +114,7 @@ event icmp_echo_request(c: connection, icmp: icmp_conn, id: count, seq: count, p
                 {
                 if ( orig !in conn_pair )
                         {
-                        local empty_peer_set2: set[addr] &mergeable;
+                        local empty_peer_set2: set[addr] ; ##&mergeable;
                         conn_pair[orig] = empty_peer_set2;
                         }
 

--- a/scripts/icmp-new-scan.bro
+++ b/scripts/icmp-new-scan.bro
@@ -186,8 +186,16 @@ event icmp_sent (c: connection , icmp: icmp_conn )
 
 } 
 
-
+@ifndef(zeek_done)
+#Running on old bro that doesn't know about zeek events
+global zeek_done: event();
 event bro_done()
+{
+    event zeek_done();
+}
+@endif
+
+event zeek_done()
         {
         for ( orig in distinct_peers )
                 scan_summary(distinct_peers, orig);

--- a/scripts/identify-web-spiders.bro
+++ b/scripts/identify-web-spiders.bro
@@ -23,7 +23,8 @@ event http_request(c: connection, method: string, original_URI: string, unescape
 			local _msg = fmt("web-spider seeking %s", original_URI) ; 
 			NOTICE([$note=WebCrawler, $src=orig, $msg=fmt("%s", _msg)]);
                         
-			event Scan::m_w_add_ip(orig, _msg); 
+			#event Scan::m_w_add_ip(orig, _msg); 
+			Broker::publish(Cluster::worker_topic,Scan::m_w_add_ip, orig, _msg);
 		} 
 	}
 } 
@@ -40,7 +41,8 @@ event http_header(c: connection, is_orig: bool, name: string, value: string) &pr
 			{ 
 				local _msg = fmt ("%s crawler is seen: %s", orig, value); 
 				NOTICE([$note=WebCrawler, $src=orig, $msg=fmt("%s", _msg)]);
-				event Scan::m_w_add_ip(orig, _msg) ; 
+				#event Scan::m_w_add_ip(orig, _msg) ; 
+				Broker::publish(Cluster::worker_topic,Scan::m_w_add_ip, orig, _msg);
 			} 
 		} 
 } 

--- a/scripts/netcontrol-scan-rules.bro
+++ b/scripts/netcontrol-scan-rules.bro
@@ -1,3 +1,6 @@
+@load base/frameworks/cluster
+@load base/frameworks/netcontrol
+@load policy/frameworks/netcontrol/catch-and-release
 
 module NetControl; 
 

--- a/scripts/netcontrol-scan-rules.bro
+++ b/scripts/netcontrol-scan-rules.bro
@@ -18,7 +18,8 @@ event NetControl::catch_release_forgotten (a: addr, bi: BlockInfo)
         {
                 Scan::known_scanners[a]$status = F ;
                 ### send the status to all workers ;
-                event Scan::m_w_update_scanner(a, F );
+                #event Scan::m_w_update_scanner(a, F );
+		Broker::publish(Cluster::worker_topic, Scan::m_w_update_scanner, a, F );
                 Scan::log_reporter(fmt ("netcontro: catch_release_forgotten: m_w_update_scanner: F %s", a),1);
         }
         else
@@ -38,7 +39,8 @@ event NetControl::rule_added(r: Rule, p: PluginState, msg: string &default="") &
         {
                 Scan::known_scanners[ip]$status = T ;
                 ### send the status to all workers ;
-                event Scan::m_w_update_scanner(ip, T );
+                #event Scan::m_w_update_scanner(ip, T );
+		Broker::publish(Cluster::worker_topic, Scan::m_w_update_scanner, ip, T );
                 Scan::log_reporter(fmt ("netcontro: event m_w_update_scanner: T %s", ip),1);
         }
 
@@ -59,7 +61,8 @@ event NetControl::rule_removed(r: Rule, p: PluginState, msg: string &default="")
 #	{ 	
 #		Scan::known_scanners[ip]$status = F ; 
 #		### send the status to all workers ;  
-#		event Scan::m_w_update_scanner(ip, F ); 
+#		#event Scan::m_w_update_scanner(ip, F ); 
+#		Broker::publish(Cluster::worker_topic, Scan::m_w_update_scanner, ip, F );
 #		Scan::log_reporter(fmt ("netcontro: event m_w_update_scanner: F %s", ip),1);
 #	} 
 #	else 	

--- a/scripts/netcontrol-scan-rules.bro
+++ b/scripts/netcontrol-scan-rules.bro
@@ -32,6 +32,7 @@ event NetControl::rule_added(r: Rule, p: PluginState, msg: string &default="") &
         {
 	 local ip = subnet_to_addr(r$entity$ip) ; 
 	 #event Scan::m_w_send_known_scan_stats(ip, T); 
+	 #Broker::publish(Cluster::worker_topic, Scan::m_w_send_known_scan_stats, ip, T );
 	 #Scan::log_reporter(fmt ("netcontro: m_w_send_known_scan_stats: %s", subnet_to_addr(r$entity$ip)),1);
 	 Scan::log_reporter(fmt ("acld_rule_added: Rule: %s, %s", subnet_to_addr(r$entity$ip), r),1);
 

--- a/scripts/netcontrol-scan-rules.bro
+++ b/scripts/netcontrol-scan-rules.bro
@@ -55,6 +55,7 @@ event NetControl::rule_removed(r: Rule, p: PluginState, msg: string &default="")
 
 	#### no need to send this - we piggyback on m_w_update_scanner 
 	##### event Scan::m_w_send_scan_summary_stats(ip, T); 
+	##### Broker::publish(Cluster::worker_topic, Scan::m_w_send_scan_summary_stats, ip, T );
 	###	Scan::log_reporter(fmt ("netcontro: acld_remove: m_w_send_known_scan_stats: %s", subnet_to_addr(r$entity$ip)),1);
 
 	### re-enabling scan-detection once netcontrol block is removed 

--- a/scripts/old-scan.bro
+++ b/scripts/old-scan.bro
@@ -385,7 +385,7 @@ function check_scan(c: connection, established: bool, reverse: bool): bool
 				{ # XXXXX
 
 				if ( orig !in distinct_peers )
-					distinct_peers[orig] = set() &mergeable;
+					distinct_peers[orig] = set() ; ##&mergeable;
 
 				if ( resp !in distinct_peers[orig] )
 					add distinct_peers[orig][resp];
@@ -454,7 +454,7 @@ function check_scan(c: connection, established: bool, reverse: bool): bool
 	if ( orig !in distinct_ports || service !in distinct_ports[orig] )
 		{
 		if ( orig !in distinct_ports )
-			distinct_ports[orig] = set() &mergeable;
+			distinct_ports[orig] = set() ; ##&mergeable;
 
 		if ( service !in distinct_ports[orig] )
 			add distinct_ports[orig][service];
@@ -462,7 +462,7 @@ function check_scan(c: connection, established: bool, reverse: bool): bool
 		if ( |distinct_ports[orig]| >= possible_port_scan_thresh &&
 			orig !in scan_triples )
 			{
-			scan_triples[orig] = table() &mergeable;
+			scan_triples[orig] = table() ; ##&mergeable;
 			add possible_scan_sources[orig];
 			}
 		}
@@ -475,7 +475,7 @@ function check_scan(c: connection, established: bool, reverse: bool): bool
 		     service !in distinct_low_ports[orig] )
 			{
 			if ( orig !in distinct_low_ports )
-				distinct_low_ports[orig] = set() &mergeable;
+				distinct_low_ports[orig] = set() ; ##&mergeable;
 
 			add distinct_low_ports[orig][service];
 
@@ -503,10 +503,10 @@ function check_scan(c: connection, established: bool, reverse: bool): bool
 	if ( orig in possible_scan_sources )
 		{
 		if ( orig !in scan_triples )
-			scan_triples[orig] = table() &mergeable;
+			scan_triples[orig] = table() ; ##&mergeable;
 
 		if ( resp !in scan_triples[orig] )
-			scan_triples[orig][resp] = set() &mergeable;
+			scan_triples[orig][resp] = set() ; ##&mergeable;
 
 		if ( service !in scan_triples[orig][resp] )
 			{

--- a/scripts/old-scan.bro
+++ b/scripts/old-scan.bro
@@ -706,8 +706,17 @@ event connection_pending(c: connection)
 		OldScan::check_scan(c, F, F);
 	}
 
-# Report the remaining entries in the tables.
+@ifndef(zeek_done)
+#Running on old bro that doesn't know about zeek events
+global zeek_done: event();
 event bro_done()
+{
+    event zeek_done();
+}
+@endif
+
+# Report the remaining entries in the tables.
+event zeek_done()
 	{
 	for ( orig in distinct_peers )
 		scan_summary(distinct_peers, orig);

--- a/scripts/port-scan.bro
+++ b/scripts/port-scan.bro
@@ -113,7 +113,7 @@ function check_lowporttrolling(orig: addr, service: port, resp: addr): bool
 	     service !in distinct_low_ports[orig] )
 		{
 		if ( orig !in distinct_low_ports )
-			distinct_low_ports[orig] = set() &mergeable;
+			distinct_low_ports[orig] = set() ; ##&mergeable;
 
 		add distinct_low_ports[orig][service];
 
@@ -145,10 +145,10 @@ function check_portscan_thresh(orig: addr, service:port, resp: addr): bool
 {
 
 	if ( orig !in scan_triples )
-		scan_triples[orig] = table() &mergeable;
+		scan_triples[orig] = table() ; ##&mergeable;
 
 	if ( resp !in scan_triples[orig] )
-		scan_triples[orig][resp] = set() &mergeable;
+		scan_triples[orig][resp] = set() ; ##&mergeable;
 
 	if ( service !in scan_triples[orig][resp] )
 	{
@@ -210,7 +210,7 @@ function check_PortScan(c: connection, established: bool, reverse: bool)
 	if ( orig !in distinct_ports || service !in distinct_ports[orig] )
 		{
 		if ( orig !in distinct_ports )
-			distinct_ports[orig] = set() &mergeable;
+			distinct_ports[orig] = set() ; ##&mergeable;
 
 		if ( service !in distinct_ports[orig] )
 			add distinct_ports[orig][service];
@@ -218,7 +218,7 @@ function check_PortScan(c: connection, established: bool, reverse: bool)
 		if ( |distinct_ports[orig]| >= possible_port_scan_thresh &&
 			orig !in scan_triples )
 			{
-			scan_triples[orig] = table() &mergeable;
+			scan_triples[orig] = table() ; ##&mergeable;
 			add possible_scan_sources[orig];
 			}
 		}
@@ -268,7 +268,7 @@ event Scan::w_m_portscan_new(orig: addr, service: port, resp: addr, outbound: bo
 	  if ( orig !in distinct_ports || service !in distinct_ports[orig] )
                 {
                 if ( orig !in distinct_ports )
-                        distinct_ports[orig] = set() &mergeable;
+                        distinct_ports[orig] = set() ; ##&mergeable;
 
                 if ( service !in distinct_ports[orig] )
                         add distinct_ports[orig][service];
@@ -276,7 +276,7 @@ event Scan::w_m_portscan_new(orig: addr, service: port, resp: addr, outbound: bo
                 if ( |distinct_ports[orig]| >= possible_port_scan_thresh &&
                         orig !in scan_triples )
                         {
-                        scan_triples[orig] = table() &mergeable;
+                        scan_triples[orig] = table() ; ##&mergeable;
                         add possible_scan_sources[orig];
                         }
                 }

--- a/scripts/port-scan.bro
+++ b/scripts/port-scan.bro
@@ -72,7 +72,7 @@ export {
 @if ( Cluster::is_enabled() )
 @load base/frameworks/cluster
 #redef Cluster::manager2worker_events += /Scan::m_w_portscan_update_known_scanners/;
-redef Cluster::worker2manager_events += /Scan::w_m_portscan_new/;
+#redef Cluster::worker2manager_events += /Scan::w_m_portscan_new/;
 @endif
 
 
@@ -244,17 +244,18 @@ function check_PortScan(c: connection, established: bool, reverse: bool)
 	local _msg = fmt (" add_to_likely_scanner: calling w_m_portscan_new for %s, %s, %s", orig, service, resp);
 	log_reporter(_msg, 0); 
 	
-	event Scan::w_m_portscan_new(orig, service, resp, outbound);
+	#event Scan::w_m_portscan_new(orig, service, resp, outbound);
+	Broker::publish(Cluster::manager_topic, Scan::w_m_portscan_new, orig, service, resp, outbound);
 @endif 
 	}	# end if established 
 } 
 
 
 
-@if ( Cluster::is_enabled() && Cluster::local_node_type() == Cluster::MANAGER )
+#@if ( Cluster::is_enabled() && Cluster::local_node_type() == Cluster::MANAGER )
 event Scan::w_m_portscan_new(orig: addr, service: port, resp: addr, outbound: bool)
 {
-
+@if ( Cluster::is_enabled() && Cluster::local_node_type() == Cluster::MANAGER )
         local msg = fmt (" inside w_m_portscan_new for %s, %s, %s", orig, service, resp);
         log_reporter(msg, 0);
 
@@ -302,7 +303,8 @@ event Scan::w_m_portscan_new(orig: addr, service: port, resp: addr, outbound: bo
                 local _msg = fmt ("w_m_portscan_new: calling m_w_portscan_update_known_scanners for: %s, %s, %s", orig, service, resp);
                 log_reporter(_msg, 0);
 
-                event Scan::m_w_portscan_update_known_scanners(orig);
+                #event Scan::m_w_portscan_update_known_scanners(orig);
+		Broker::publish(Cluster::worker_topic, Scan::m_w_portscan_update_known_scanners, orig);
 
                 if (orig !in Scan::known_scanners)
 		{ 
@@ -316,28 +318,28 @@ event Scan::w_m_portscan_new(orig: addr, service: port, resp: addr, outbound: bo
 		} 
 
         }
-
-}
 @endif
+}
+#@endif
 
 
 # we can get away with only sending orig here since thats what is used to update
 # known_scanners table on workers , we are still sending d_port, resp
 # for debugging assurances
 
-@if ( Cluster::is_enabled() && Cluster::local_node_type() != Cluster::MANAGER )
+#@if ( Cluster::is_enabled() && Cluster::local_node_type() != Cluster::MANAGER )
 event Scan::m_w_portscan_update_known_scanners(orig: addr)
 {
-
+@if ( Cluster::is_enabled() && Cluster::local_node_type() == Cluster::WORKER )
 
         if (orig !in Scan::known_scanners)
                 Scan::known_scanners[orig]$status = T ;
         
 	local msg = fmt ("portscan: added m_w_portscan_update_known_scanners for: %s, %s, %s", orig, Scan::known_scanners[orig], |Scan::known_scanners[orig]|);
         log_reporter(msg, 0);
-
-}
 @endif
+}
+#@endif
 
 
 

--- a/scripts/port-scan.bro
+++ b/scripts/port-scan.bro
@@ -126,7 +126,6 @@ function check_lowporttrolling(orig: addr, service: port, resp: addr): bool
 
 			local svrc_msg = fmt("low port trolling %s %s", orig, s);
 			NOTICE([$note=LowPortTrolling, $src=orig,
-				$src_peer=get_local_event_peer(), 
 				$p=service, $msg=svrc_msg]);
 
 			troll = T ; 
@@ -162,7 +161,6 @@ function check_portscan_thresh(orig: addr, service:port, resp: addr): bool
 			local m = |scan_triples[orig][resp]|;
 			NOTICE([$note=PortScan, $n=m, $src=orig,
 				$p=service,
-				$src_peer=get_local_event_peer(), 
 				$msg=fmt("%s has scanned %d ports of %s",
 				orig, m, resp)]);
 			return T ; 

--- a/scripts/scan-base.bro
+++ b/scripts/scan-base.bro
@@ -109,6 +109,8 @@ export {
 	global dont_drop: function(a: addr): bool ; 
 	global can_drop_connectivity = F &redef ; 
 	global dont_drop_locals = T &redef ; 
+	
+	global Scan::table_sizes: event ();
 
 
 }  #### end of export 

--- a/scripts/scan-base.bro
+++ b/scripts/scan-base.bro
@@ -125,8 +125,8 @@ export {
 
 @if ( Cluster::is_enabled() )
 @load base/frameworks/cluster
-redef Cluster::manager2worker_events += /Scan::m_w_(add|remove|update)_scanner/;
-redef Cluster::worker2manager_events += /Scan::w_m_(new|add|remove|update)_scanner/;
+#redef Cluster::manager2worker_events += /Scan::m_w_(add|remove|update)_scanner/;
+#redef Cluster::worker2manager_events += /Scan::w_m_(new|add|remove|update)_scanner/;
 @endif
 
 
@@ -172,7 +172,8 @@ function known_scanners_inactive(t: table[addr] of scan_info, idx: addr): interv
 	### sending message to all workers to delete this scanner 
 	### since its inactive now 
 
-	event Scan::m_w_remove_scanner(idx); 
+	#event Scan::m_w_remove_scanner(idx); 
+	Broker::publish(Cluster::worker_topic, Scan::m_w_remove_scanner, idx);
 
 	### delete from the manager too 
 
@@ -297,7 +298,7 @@ function print_state(s: count, t: transport_proto): string
 }
 
 
-event table_sizes()
+event Scan::table_sizes()
 {
 
 	return ; 
@@ -331,7 +332,7 @@ event table_sizes()
 	#log_reporter(fmt("table_size: whitelist_ip_table: %s",|whitelist_ip_table|),0);
 	#log_reporter(fmt("table_size: whitelist_subnet_table: %s",|whitelist_subnet_table|),0);
 
-	schedule 10 mins { table_sizes() } ; 
+	schedule 10 mins { Scan::table_sizes() } ; 
 
 } 
 

--- a/scripts/scan-base.bro
+++ b/scripts/scan-base.bro
@@ -44,7 +44,7 @@ export {
 	### workers will keep known_scanners until manager sends m_w_remove_scanner event 
 	### when manager calls known_scanners_inactive event 
 
-@if ( Cluster::is_enabled() && Cluster::local_node_type() != Cluster::MANAGER )
+@if ( Cluster::is_enabled() && Cluster::local_node_type() == Cluster::WORKER )
         global known_scanners: table[addr] of scan_info ; 
 @endif 
 

--- a/scripts/scan-base.bro
+++ b/scripts/scan-base.bro
@@ -384,7 +384,7 @@ function hot_subnet_check(ip: addr)
 	{ 
 		local _msg = fmt ("%s has %s scanners originating from it", scanner_subnet, n); 
 	
-		NOTICE([$note=HotSubnet,  $src_peer=get_local_event_peer(), $src=ip, $msg=fmt("%s", _msg)]);
+		NOTICE([$note=HotSubnet, $src=ip, $msg=fmt("%s", _msg)]);
 	} 
 
 }

--- a/scripts/scan-base.bro
+++ b/scripts/scan-base.bro
@@ -44,7 +44,7 @@ export {
 	### workers will keep known_scanners until manager sends m_w_remove_scanner event 
 	### when manager calls known_scanners_inactive event 
 
-@if ( Cluster::is_enabled() && Cluster::local_node_type() == Cluster::WORKER )
+@if ( Cluster::is_enabled() && Cluster::local_node_type() != Cluster::MANAGER )
         global known_scanners: table[addr] of scan_info ; 
 @endif 
 

--- a/scripts/scan-inputs.bro
+++ b/scripts/scan-inputs.bro
@@ -287,8 +287,7 @@ event Scan::m_w_add_subnet(nets: subnet, comment: string)
 
 				local _msg = fmt("%s is removed from known_scanners after %s whitelist: %s", ip, nets, known_scanners[ip]);
 
-				NOTICE([$note=PurgeOnWhitelist, $src=ip,
-					$src_peer=get_local_event_peer(), $msg=fmt("%s", _msg)]);
+				NOTICE([$note=PurgeOnWhitelist, $src=ip, $msg=fmt("%s", _msg)]);
 				delete known_scanners[ip] ;
 
 				@ifdef (NetControl::unblock_address_catch_release) 

--- a/scripts/scan-inputs.bro
+++ b/scripts/scan-inputs.bro
@@ -1,6 +1,13 @@
+@ifndef(zeek_init)
+#Running on old bro that doesn't know about zeek events
+global zeek_init: event();
+event bro_init()
+{
+    event zeek_init();
+}
+@endif
+
 module Scan;
-
-
 #redef exit_only_after_terminate = T ; 
 
 export {
@@ -65,10 +72,9 @@ export {
 
 }
 
-
 @if ( Cluster::is_enabled() )
 @load base/frameworks/cluster
-redef Cluster::manager2worker_events += /Scan::m_w_(add|update|remove)_(ip|subnet)/;
+#redef Cluster::manager2worker_events += /Scan::m_w_(add|update|remove)_(ip|subnet)/;
 @endif
 
 event reporter_error(t: time , msg: string , location: string )
@@ -102,7 +108,8 @@ event read_whitelist_ip(description: Input::TableDescription, tpe: Input::Event,
                 NOTICE([$note=WhitelistAdd, $src=ip, $msg=fmt("%s", _msg)]);
 
 	@if ( Cluster::is_enabled() )
-	        	event Scan::m_w_add_ip(ip, comment) ; 
+	        	#event Scan::m_w_add_ip(ip, comment) ; 
+			Broker::publish(Cluster::worker_topic, Scan::m_w_add_ip, ip, comment);
 	@endif	
 
         }
@@ -116,7 +123,8 @@ event read_whitelist_ip(description: Input::TableDescription, tpe: Input::Event,
                 NOTICE([$note=WhitelistChanged, $src=ip, $msg=fmt("%s", _msg)]);
 
 	@if ( Cluster::is_enabled() )
-	        	event Scan::m_w_update_ip(ip, comment) ; 
+	        	#event Scan::m_w_update_ip(ip, comment) ; 
+			Broker::publish(Cluster::worker_topic, Scan::m_w_update_ip, ip, comment);
 	@endif	
         }
 
@@ -130,7 +138,8 @@ event read_whitelist_ip(description: Input::TableDescription, tpe: Input::Event,
                 NOTICE([$note=WhitelistRemoved, $src=ip, $msg=fmt("%s", _msg)]);
 
 	@if ( Cluster::is_enabled() )
-	        	event Scan::m_w_remove_ip(ip, comment) ; 
+	        	#event Scan::m_w_remove_ip(ip, comment) ; 
+			Broker::publish(Cluster::worker_topic, Scan::m_w_remove_ip, ip, comment);
 	@endif	
         }
 	
@@ -170,7 +179,8 @@ event read_whitelist_subnet(description: Input::TableDescription, tpe: Input::Ev
                 NOTICE([$note=WhitelistAdd, $msg=fmt("%s", _msg)]);
 		
 	@if ( Cluster::is_enabled() )
-	        	event Scan::m_w_add_subnet(nets, comment);
+	        	#event Scan::m_w_add_subnet(nets, comment);
+			Broker::publish(Cluster::worker_topic, Scan::m_w_add_subnet, nets, comment);
 	@endif	
         }
 
@@ -183,7 +193,8 @@ event read_whitelist_subnet(description: Input::TableDescription, tpe: Input::Ev
                 NOTICE([$note=WhitelistChanged, $msg=fmt("%s", _msg)]);
 	
 	@if ( Cluster::is_enabled() )
-	        	event Scan::m_w_update_subnet(nets, comment);
+	        	#event Scan::m_w_update_subnet(nets, comment);
+			Broker::publish(Cluster::worker_topic, Scan::m_w_update_subnet, nets, comment);
 	@endif	
         }
 
@@ -195,14 +206,15 @@ event read_whitelist_subnet(description: Input::TableDescription, tpe: Input::Ev
 		NOTICE([$note=WhitelistRemoved, $msg=fmt("%s", _msg)]);
 
 	@if ( Cluster::is_enabled() )
-		event Scan::m_w_remove_subnet(nets, comment) ; 
+		#event Scan::m_w_remove_subnet(nets, comment) ; 
+		Broker::publish(Cluster::worker_topic, Scan::m_w_remove_subnet, nets, comment);
 	@endif	
         }
 
 
 }
 
-@if ( Cluster::is_enabled() && Cluster::local_node_type() != Cluster::MANAGER )
+@if ( Cluster::is_enabled() && Cluster::local_node_type() == Cluster::WORKER )
 event Scan::m_w_add_ip(ip: addr, comment: string)
         {
 
@@ -330,13 +342,21 @@ if ( ! Cluster::is_enabled() || Cluster::local_node_type() == Cluster::MANAGER )
 }
 
 
-event bro_init() &priority=5
+event zeek_init() &priority=5
 {
 schedule read_whitelist_timer  { read_whitelist() }; 
 }
 
-
+@ifndef(zeek_done)
+#Running on old bro that doesn't know about zeek events
+global zeek_done: event();
 event bro_done()
+{
+    event zeek_done();
+}
+@endif
+
+event zeek_done()
 {
 	#for ( ip in whitelist_ip_table)
 	#{

--- a/scripts/scan-summary.bro
+++ b/scripts/scan-summary.bro
@@ -350,7 +350,7 @@ function manager_update_scan_summary(idx: addr, stats: scan_stats)
 		 ### add to the previous counts 
 		Scan::scan_summary[idx]$total_conn = Scan::scan_summary[idx]$total_conn + stats$total_conn;
 
-	        Scan::scan_summary[idx]$event_peer = stats?$event_peer ? stats$event_peer : fmt ("%s",get_event_peer()$descr);
+	        Scan::scan_summary[idx]$event_peer = stats?$event_peer ? stats$event_peer : fmt ("");
 
 		hll_cardinality_merge_into(scan_summary[idx]$hosts, stats$hosts); 
 

--- a/scripts/scan-summary.bro
+++ b/scripts/scan-summary.bro
@@ -237,7 +237,7 @@ function workers_update_scan_summary(idx: addr)
 	
 		hll_cardinality_merge_into(scan_summary[idx]$hosts, conn_table[idx]$hosts); 
 
-		local peer = get_event_peer()  ;
+		#local peer = get_event_peer()  ;
 		scan_summary[idx]$event_peer = fmt ("%s", peer_description ); 
 
 		 local zero_time = double_to_time(0.0);

--- a/scripts/scan-summary.bro
+++ b/scripts/scan-summary.bro
@@ -56,7 +56,7 @@ export {
 
 	const conn_table_create_expire: interval = 20 mins &redef; 
 
-        global report_conn_stats: function(t: table[addr] of count, idx: addr): interval;
+        global report_conn_stats: function(t: table[addr] of conn_stats, idx: addr): interval;
 	global conn_table: table[addr] of conn_stats 
 			&create_expire=conn_table_create_expire &expire_func=report_conn_stats ; 
 
@@ -131,7 +131,7 @@ function initialize_scan_summary(idx: addr)
 ##### expire_func for conn_table to update or populate scan_summary on workers 
 
 #@if ( Cluster::is_enabled() && Cluster::local_node_type() == Cluster::WORKER ) 
-function report_conn_stats(t: table[addr] of count, idx: addr): interval 
+function report_conn_stats(t: table[addr] of conn_stats, idx: addr): interval 
 { 
 	if (idx in Scan::known_scanners) 
 	{ 

--- a/scripts/site-subnets.bro
+++ b/scripts/site-subnets.bro
@@ -1,3 +1,12 @@
+@ifndef(zeek_init)
+#Running on old bro that doesn't know about zeek events
+global zeek_init: event();
+event bro_init()
+{
+    event zeek_init();
+}
+@endif
+
 module Site  ; 
 
 #redef exit_only_after_terminate = T ; 
@@ -66,7 +75,7 @@ event Input::end_of_data(name: string, source: string)
 	} 
 } 
 
-event bro_init() &priority=10
+event zeek_init() &priority=10
 {
         Input::add_table([$source=subnet_feed, $name="subnet_table", $idx=subnet_Idx, $val=subnet_Val,  $destination=subnet_table, $mode=Input::REREAD]);  
         
@@ -75,8 +84,16 @@ event bro_init() &priority=10
  #       $pred(typ: Input::Event, left: subnet_Idx, right: subnet_Val = { left$epo = to_lower(left$epo); return T;) }]);
 }
 
-
+@ifndef(zeek_done)
+#Running on old bro that doesn't know about zeek events
+global zeek_done: event();
 event bro_done()
+{
+    event zeek_done();
+}
+@endif
+
+event zeek_done()
 {
 	#print fmt("bro-done subnet-bro"); 
 	#print fmt("digested  %s records in subnet_table", |Site::subnet_table|);

--- a/scripts/skip-services.bro
+++ b/scripts/skip-services.bro
@@ -1,5 +1,14 @@
 #redef exit_only_after_terminate=T ;
 
+@ifndef(zeek_init)
+#Running on old bro that doesn't know about zeek events
+global zeek_init: event();
+event bro_init()
+{
+    event zeek_init();
+}
+@endif
+
 module Scan;
 
 export {
@@ -44,11 +53,20 @@ event port_exclude(description: Input::TableDescription, tpe: Input::Event, left
 	} 
 }
 
-event bro_init() {
+event zeek_init() {
 	Input::add_table([$source=portexclude_file, $mode=Input::REREAD, $name="port_exclude", $destination=port_exclude_table, $idx=Idx, $val=portexclude_Val, $ev=port_exclude]);
 }
 
+@ifndef(zeek_done)
+#Running on old bro that doesn't know about zeek events
+global zeek_done: event();
 event bro_done()
+{
+    event zeek_done();
+}
+@endif
+
+event zeek_done()
 {
 
 	for (p in skip_services) 

--- a/scripts/skip_services.bro
+++ b/scripts/skip_services.bro
@@ -1,5 +1,14 @@
 redef exit_only_after_terminate=T ;
 
+@ifndef(zeek_init)
+#Running on old bro that doesn't know about zeek events
+global zeek_init: event();
+event bro_init()
+{
+    event zeek_init();
+}
+@endif
+
 module Scan;
 
 export {
@@ -43,11 +52,20 @@ event port_exclude(description: Input::TableDescription, tpe: Input::Event, left
 	} 
 }
 
-event bro_init() {
+event zeek_init() {
 	Input::add_table([$source=portexclude_file, $mode=Input::REREAD, $name="port_exclude", $destination=port_exclude_table, $idx=Idx, $val=portexclude_Val, $ev=port_exclude]);
 }
 
+@ifndef(zeek_done)
+#Running on old bro that doesn't know about zeek events
+global zeek_done: event();
 event bro_done()
+{
+    event zeek_done();
+}
+@endif
+
+event zeek_done()
 {
 
 	for (p in skip_services) 

--- a/scripts/trw-impl.bro
+++ b/scripts/trw-impl.bro
@@ -1,5 +1,14 @@
 # $Id: trw.bro 2911 2006-05-06 17:58:43Z vern $
 
+@ifndef(zeek_init)
+#Running on old bro that doesn't know about zeek events
+global zeek_init: event();
+event bro_init()
+{
+    event zeek_init();
+}
+@endif
+
 module TRW;
 
 export {
@@ -61,10 +70,9 @@ global honeypot: set[addr];
 global eta_zero: double;	# initialized when Bro starts
 global eta_one: double;
 
-event bro_init()
+event zeek_init()
 	{
-	eta_zero =
-		(1 - target_detection_prob) / (1 - target_false_positive_prob);
+	eta_zero = (1 - target_detection_prob) / (1 - target_false_positive_prob);
 	eta_one = target_detection_prob / target_false_positive_prob;
 	}
 


### PR DESCRIPTION
Ported scripts to be able to run in Zeek 3.0 to use Broker communication FW, and removal of some old communication framework functions such as 'get_event_peer() and get_local_event_peer()'.

